### PR TITLE
Implement VSCode git confirmation extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ project, please check the [project management guide](./PROJECT.md) to get starte
 - ✅ Deploy directly to Netlify (@xKevIsDev)
 - ✅ Supabase Integration (@xKevIsDev)
 - ⬜ Have LLM plan the project in a MD file for better results/transparency
-- ⬜ VSCode Integration with git-like confirmations
+- ✅ VSCode Integration with git-like confirmations
 - ⬜ Upload documents for knowledge - UI design templates, a code base to reference coding style, etc.
 - ✅ Voice prompting
 - ⬜ Azure Open AI API Integration

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "bolt-diy-git-confirmation",
+  "displayName": "Bolt.diy Git Confirmation",
+  "description": "Show git-like confirmations for file changes inside VS Code",
+  "version": "0.0.1",
+  "publisher": "bolt-diy",
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "activationEvents": [
+    "onCommand:bolt.gitConfirm"
+  ],
+  "main": "./dist/extension.js",
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "prepublishOnly": "npm run compile"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.2",
+    "@types/node": "^20.0.0",
+    "vscode": "^1.1.39"
+  }
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,0 +1,56 @@
+import * as vscode from 'vscode';
+import { exec } from 'child_process';
+
+export function activate(context: vscode.ExtensionContext) {
+  const disposable = vscode.commands.registerCommand('bolt.gitConfirm', () => {
+    const folders = vscode.workspace.workspaceFolders;
+    if (!folders || folders.length === 0) {
+      vscode.window.showErrorMessage('No workspace folder found.');
+      return;
+    }
+
+    const cwd = folders[0].uri.fsPath;
+    exec('git status --porcelain', { cwd }, (err, stdout) => {
+      if (err) {
+        vscode.window.showErrorMessage('Failed to run git.');
+        return;
+      }
+
+      const lines = stdout.trim().split(/\r?\n/).filter(Boolean);
+      if (lines.length === 0) {
+        vscode.window.showInformationMessage('No changes to confirm.');
+        return;
+      }
+
+      const files = lines.map((l) => l.slice(3));
+      vscode.window.showQuickPick(files, { placeHolder: 'Select a file to review' }).then((file) => {
+        if (!file) {
+          return;
+        }
+
+        exec(`git diff -- ${file}`, { cwd }, (diffErr, diff) => {
+          if (diffErr) {
+            vscode.window.showErrorMessage('Failed to get diff.');
+            return;
+          }
+
+          vscode.workspace.openTextDocument({ content: diff, language: 'diff' }).then((doc) => {
+            vscode.window.showTextDocument(doc, { preview: true }).then(() => {
+              vscode.window.showInformationMessage(`Stage ${file}?`, 'Yes', 'No').then((answer) => {
+                if (answer === 'Yes') {
+                  exec(`git add ${file}`, { cwd }, () => {
+                    vscode.window.showInformationMessage(`Staged ${file}`);
+                  });
+                }
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  context.subscriptions.push(disposable);
+}
+
+export function deactivate() {}

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2022",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "sourceMap": true
+  },
+  "exclude": ["node_modules", ".vscode-test"]
+}


### PR DESCRIPTION
## Summary
- add VSCode extension to show git diffs and stage files upon confirmation
- update README checklist

## Testing
- `pnpm test` *(fails: vitest not found)*
- `pnpm lint` *(fails: ESLint config dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841feb271388323a14db0e5a7a19882

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement a VSCode extension named "Bolt.diy Git Confirmation" to provide git-like confirmation dialogs for file changes within VSCode.

### Why are these changes being made?

The aim is to enhance user workflow by enabling seamless review and staging of file changes directly in VSCode, mimicking the behavior of git clients. This extension addresses the need for a more integrated and efficient confirmation process when working inside VSCode, reducing context switches and improving productivity.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->