### PR TITLE
Add file targeting via context menu

### DIFF
--- a/app/components/workbench/FileTree.tsx
+++ b/app/components/workbench/FileTree.tsx
@@ -442,6 +442,38 @@ function FileContextMenu({
     }
   };
 
+  const handleTargetFile = () => {
+    try {
+      if (isFolder) {
+        return;
+      }
+
+      const success = workbenchStore.targetFile(fullPath);
+      if (success) {
+        toast.success(`File targeted`);
+      }
+    } catch (error) {
+      toast.error('Error targeting file');
+      logger.error(error);
+    }
+  };
+
+  const handleUnTargetFile = () => {
+    try {
+      if (isFolder) {
+        return;
+      }
+
+      const success = workbenchStore.unTargetFile(fullPath);
+      if (success) {
+        toast.success(`File un-targeted`);
+      }
+    } catch (error) {
+      toast.error('Error removing target');
+      logger.error(error);
+    }
+  };
+
   // Handler for locking a folder with full lock
   const handleLockFolder = () => {
     try {
@@ -535,6 +567,18 @@ function FileContextMenu({
                     <div className="flex items-center gap-2">
                       <div className="i-ph:lock-key-open" />
                       Unlock File
+                    </div>
+                  </ContextMenuItem>
+                  <ContextMenuItem onSelect={handleTargetFile}>
+                    <div className="flex items-center gap-2">
+                      <div className="i-ph:crosshair" />
+                      Target File
+                    </div>
+                  </ContextMenuItem>
+                  <ContextMenuItem onSelect={handleUnTargetFile}>
+                    <div className="flex items-center gap-2">
+                      <div className="i-ph:target" />
+                      Un-target File
                     </div>
                   </ContextMenuItem>
                 </>
@@ -643,6 +687,7 @@ function File({
 
   // Check if the file is locked
   const { locked } = workbenchStore.isFileLocked(fullPath);
+  const isTargeted = workbenchStore.isFileTargeted(fullPath);
 
   const fileModifications = fileHistory[fullPath];
 
@@ -715,6 +760,9 @@ function File({
                 className={classNames('shrink-0', 'i-ph:lock-simple scale-80 text-red-500')}
                 title={'File is locked'}
               />
+            )}
+            {isTargeted && (
+              <span className="shrink-0 i-ph:crosshair text-green-500 scale-80" title="Targeted file" />
             )}
             {unsavedChanges && <span className="i-ph:circle-fill scale-68 shrink-0 text-orange-500" />}
           </div>

--- a/app/lib/persistence/targetedFiles.ts
+++ b/app/lib/persistence/targetedFiles.ts
@@ -1,0 +1,98 @@
+export const TARGETED_FILES_KEY = 'bolt.targetedFiles';
+
+export interface TargetedFile {
+  chatId: string;
+  path: string;
+}
+
+let targetedFilesCache: TargetedFile[] | null = null;
+const targetedFilesMap = new Map<string, Set<string>>();
+
+function getChatSet(chatId: string, create = false): Set<string> | undefined {
+  if (create && !targetedFilesMap.has(chatId)) {
+    targetedFilesMap.set(chatId, new Set());
+  }
+  return targetedFilesMap.get(chatId);
+}
+
+function initializeCache(): TargetedFile[] {
+  if (targetedFilesCache !== null) {
+    return targetedFilesCache;
+  }
+  try {
+    if (typeof localStorage !== 'undefined') {
+      const json = localStorage.getItem(TARGETED_FILES_KEY);
+      if (json) {
+        const items = JSON.parse(json) as TargetedFile[];
+        targetedFilesCache = items;
+        rebuildLookup(items);
+        return items;
+      }
+    }
+    targetedFilesCache = [];
+    return [];
+  } catch {
+    targetedFilesCache = [];
+    return [];
+  }
+}
+
+function rebuildLookup(items: TargetedFile[]): void {
+  targetedFilesMap.clear();
+  for (const item of items) {
+    let set = targetedFilesMap.get(item.chatId);
+    if (!set) {
+      set = new Set();
+      targetedFilesMap.set(item.chatId, set);
+    }
+    set.add(item.path);
+  }
+}
+
+export function saveTargetedFiles(items: TargetedFile[]): void {
+  targetedFilesCache = [...items];
+  rebuildLookup(items);
+  try {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem(TARGETED_FILES_KEY, JSON.stringify(items));
+    }
+  } catch {}
+}
+
+export function getTargetedFiles(): TargetedFile[] {
+  return initializeCache();
+}
+
+export function addTargetedFile(chatId: string, path: string): void {
+  const files = getTargetedFiles();
+  const set = getChatSet(chatId, true)!;
+  set.add(path);
+  const filtered = files.filter((f) => !(f.chatId === chatId && f.path === path));
+  filtered.push({ chatId, path });
+  saveTargetedFiles(filtered);
+}
+
+export function removeTargetedFile(chatId: string, path: string): void {
+  const files = getTargetedFiles();
+  const set = getChatSet(chatId);
+  if (set) set.delete(path);
+  const filtered = files.filter((f) => !(f.chatId === chatId && f.path === path));
+  saveTargetedFiles(filtered);
+}
+
+export function isFileTargeted(chatId: string, path: string): boolean {
+  initializeCache();
+  const set = getChatSet(chatId);
+  return set ? set.has(path) : false;
+}
+
+export function getTargetedFilesForChat(chatId: string): string[] {
+  initializeCache();
+  const set = getChatSet(chatId);
+  return set ? Array.from(set) : [];
+}
+
+export function clearCache(): void {
+  targetedFilesCache = null;
+  targetedFilesMap.clear();
+}

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -312,6 +312,14 @@ export class WorkbenchStore {
     return this.#filesStore.unlockFile(filePath);
   }
 
+  targetFile(filePath: string) {
+    return this.#filesStore.targetFile(filePath);
+  }
+
+  unTargetFile(filePath: string) {
+    return this.#filesStore.unTargetFile(filePath);
+  }
+
   /**
    * Unlock a folder and all its contents to allow edits
    * @param folderPath Path to the folder to unlock
@@ -328,6 +336,10 @@ export class WorkbenchStore {
    */
   isFileLocked(filePath: string) {
     return this.#filesStore.isFileLocked(filePath);
+  }
+
+  isFileTargeted(filePath: string) {
+    return this.#filesStore.isFileTargeted(filePath);
   }
 
   /**

--- a/app/utils/targetFiles.ts
+++ b/app/utils/targetFiles.ts
@@ -1,0 +1,47 @@
+import {
+  addTargetedFile,
+  removeTargetedFile,
+  isFileTargeted as isFileTargetedInternal,
+  getTargetedFiles,
+} from '~/lib/persistence/targetedFiles';
+import { createScopedLogger } from './logger';
+
+const logger = createScopedLogger('TargetFiles');
+
+export function getCurrentChatId(): string {
+  try {
+    if (typeof window !== 'undefined') {
+      const match = window.location.pathname.match(/\/chat\/([^/]+)/);
+      if (match && match[1]) {
+        return match[1];
+      }
+    }
+    return 'default';
+  } catch (error) {
+    logger.error('Failed to get current chat ID', error);
+    return 'default';
+  }
+}
+
+export function isFileTargeted(filePath: string, chatId?: string): boolean {
+  try {
+    const currentChatId = chatId || getCurrentChatId();
+    return isFileTargetedInternal(currentChatId, filePath);
+  } catch (error) {
+    logger.error('Failed to check if file is targeted', error);
+    return false;
+  }
+}
+
+export function hasTargetedFiles(chatId?: string): boolean {
+  try {
+    const currentChatId = chatId || getCurrentChatId();
+    const files = getTargetedFiles();
+    return files.some((f) => f.chatId === currentChatId);
+  } catch (error) {
+    logger.error('Failed to check for targeted files', error);
+    return false;
+  }
+}
+
+export { addTargetedFile, removeTargetedFile } from '~/lib/persistence/targetedFiles';


### PR DESCRIPTION
## Summary
- allow marking files for AI editing via new `targetedFiles` store
- show targeted file icon and context menu actions
- skip edits on locked or non-targeted files when applying AI actions

## Testing
- `pnpm lint` *(fails: Cannot find package '@blitz/eslint-plugin')*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684222f2153083239dfa7053a598bb26

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add functionality to target files for AI edits through a context menu within the file tree, including persistence of targeted files in local storage and corresponding UI indicators.

### Why are these changes being made?
These changes enable users to specify files as “targeted” for AI-related tasks, improving precision and efficiency when working with file edits. By incorporating targeted file management directly into the application state and UI, users gain finer control over file operations, appropriate state persistence, and visibility of targeted status through visual cues, simplifying workflow and reducing unintended file processing.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->