### PR TITLE
Add project planning button

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ project, please check the [project management guide](./PROJECT.md) to get starte
 - ✅ Deploy directly to Vercel
 - ✅ Deploy directly to Cloudflare Pages
 - ✅ Supabase Integration (@xKevIsDev)
-- ⬜ Have LLM plan the project in a MD file for better results/transparency
+- ✅ Have LLM plan the project in a MD file for better results/transparency
 - ✅ VSCode Integration with git-like confirmations
 - ⬜ Upload documents for knowledge - UI design templates, a code base to reference coding style, etc.
 - ✅ Voice prompting

--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -316,6 +316,8 @@ export const ChatImpl = memo(
 
       let finalMessageContent = messageContent;
 
+      let uploadArtifact = '';
+
       if (selectedElement) {
         console.log('Selected Element:', selectedElement);
 
@@ -437,14 +439,13 @@ export const ChatImpl = memo(
       const uploadedMap: { [path: string]: string } = {};
       uploadedFiles.forEach((file, idx) => {
         const text = textDataList[idx];
+
         if (text) {
           uploadedMap[file.name] = escapeBoltTags(text);
         }
       });
-      const uploadArtifact =
-        Object.keys(uploadedMap).length > 0
-          ? uploadedFilesToArtifacts(uploadedMap, `uploaded-${Date.now()}`)
-          : '';
+      uploadArtifact =
+        Object.keys(uploadedMap).length > 0 ? uploadedFilesToArtifacts(uploadedMap, `uploaded-${Date.now()}`) : '';
 
       if (modifiedFiles !== undefined) {
         const userUpdateArtifact = filesToArtifacts(modifiedFiles, `${Date.now()}`);

--- a/app/components/chat/ChatBox.tsx
+++ b/app/components/chat/ChatBox.tsx
@@ -296,6 +296,19 @@ export const ChatBox: React.FC<ChatBoxProps> = (props) => {
               onStop={props.stopListening}
               disabled={props.isStreaming}
             />
+            <IconButton
+              title="Plan project in MD file"
+              className="transition-all flex items-center gap-1 px-1.5"
+              onClick={(event) =>
+                props.handleSendMessage?.(
+                  event,
+                  'Plan the project in a plan.md file with sections: Files/components needed, Data flow, Deployment plan.',
+                )
+              }
+            >
+              <div className="i-ph:map-trifold text-xl" />
+              <span>Plan</span>
+            </IconButton>
             {props.chatStarted && (
               <IconButton
                 title="Discuss"

--- a/app/components/chat/FilePreview.tsx
+++ b/app/components/chat/FilePreview.tsx
@@ -7,7 +7,7 @@ interface FilePreviewProps {
   onRemove: (index: number) => void;
 }
 
-const FilePreview: React.FC<FilePreviewProps> = ({ files, imageDataList, textDataList, onRemove }) => {
+const FilePreview: React.FC<FilePreviewProps> = ({ files, imageDataList, textDataList: _textDataList, onRemove }) => {
   if (!files || files.length === 0) {
     return null;
   }

--- a/app/utils/targetFiles.ts
+++ b/app/utils/targetFiles.ts
@@ -1,9 +1,4 @@
-import {
-  addTargetedFile,
-  removeTargetedFile,
-  isFileTargeted as isFileTargetedInternal,
-  getTargetedFiles,
-} from '~/lib/persistence/targetedFiles';
+import { isFileTargeted as isFileTargetedInternal, getTargetedFiles } from '~/lib/persistence/targetedFiles';
 import { createScopedLogger } from './logger';
 
 const logger = createScopedLogger('TargetFiles');
@@ -12,10 +7,12 @@ export function getCurrentChatId(): string {
   try {
     if (typeof window !== 'undefined') {
       const match = window.location.pathname.match(/\/chat\/([^/]+)/);
+
       if (match && match[1]) {
         return match[1];
       }
     }
+
     return 'default';
   } catch (error) {
     logger.error('Failed to get current chat ID', error);
@@ -37,6 +34,7 @@ export function hasTargetedFiles(chatId?: string): boolean {
   try {
     const currentChatId = chatId || getCurrentChatId();
     const files = getTargetedFiles();
+
     return files.some((f) => f.chatId === currentChatId);
   } catch (error) {
     logger.error('Failed to check for targeted files', error);

--- a/types/external.d.ts
+++ b/types/external.d.ts
@@ -1,0 +1,3 @@
+declare module 'pdfjs-dist/build/pdf.mjs';
+declare module 'pdfjs-dist/build/pdf.worker.mjs';
+declare module 'mammoth/mammoth.browser';


### PR DESCRIPTION
## Summary
- implement `Plan project in MD file` icon button in ChatBox
- define `uploadArtifact` earlier to satisfy TypeScript
- document feature in README
- add external module declarations

## Testing
- `pnpm typecheck`
- `pnpm lint:fix`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6842259aa0fc8323a276d4d20b3aa83a

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a "Plan project in MD file" button to the ChatBox component, improve code organization and remove unused imports, and add type declarations for PDF.js and Mammoth modules.

### Why are these changes being made?

The additional button allows users to create a project plan directly in a markdown file, enhancing project transparency and planning efficiency. Unused imports are being removed to streamline the code, improving maintainability and performance. Adding type declarations accommodates PDF.js and Mammoth browser integrations, ensuring better type safety and compatibility within the application.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->