### PR TITLE
Add Ask Bolt to chat code blocks

### DIFF
--- a/app/components/chat/ChatBox.tsx
+++ b/app/components/chat/ChatBox.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { ClientOnly } from 'remix-utils/client-only';
 import { classNames } from '~/utils/classNames';
 import { PROVIDER_LIST } from '~/utils/constants';
@@ -69,6 +69,17 @@ interface ChatBoxProps {
 }
 
 export const ChatBox: React.FC<ChatBoxProps> = (props) => {
+  useEffect(() => {
+    (window as any).__BOLT_ASK_SNIPPET__ = (code: string, lang: string) => {
+      const message = `*What does this code do?*\n\`\`\`${lang || 'plaintext'}\n${code}\n\`\`\`\n`;
+      props.handleSendMessage?.({} as any, message);
+    };
+
+    return () => {
+      delete (window as any).__BOLT_ASK_SNIPPET__;
+    };
+  }, [props.handleSendMessage]);
+
   return (
     <div
       data-prompt-enhanced={props.promptEnhanced}

--- a/app/components/chat/CodeBlock.module.scss
+++ b/app/components/chat/CodeBlock.module.scss
@@ -1,5 +1,5 @@
 .CopyButtonContainer {
-  button:before {
+  .copy-button:before {
     content: 'Copied';
     font-size: 12px;
     position: absolute;

--- a/app/components/chat/CodeBlock.tsx
+++ b/app/components/chat/CodeBlock.tsx
@@ -56,7 +56,7 @@ export const CodeBlock = memo(
         <div
           className={classNames(
             styles.CopyButtonContainer,
-            'bg-transparant absolute top-[10px] right-[10px] rounded-md z-10 text-lg flex items-center justify-center opacity-0 group-hover:opacity-100',
+            'bg-transparant absolute top-[10px] right-[10px] rounded-md z-10 text-lg flex items-center justify-center gap-1 opacity-0 group-hover:opacity-100',
             {
               'rounded-l-0 opacity-100': copied,
             },
@@ -65,7 +65,7 @@ export const CodeBlock = memo(
           {!disableCopy && (
             <button
               className={classNames(
-                'flex items-center bg-accent-500 p-[6px] justify-center before:bg-white before:rounded-l-md before:text-gray-500 before:border-r before:border-gray-300 rounded-md transition-theme',
+                'copy-button flex items-center bg-accent-500 p-[6px] justify-center before:bg-white before:rounded-l-md before:text-gray-500 before:border-r before:border-gray-300 rounded-md transition-theme',
                 {
                   'before:opacity-0': !copied,
                   'before:opacity-100': copied,
@@ -77,6 +77,18 @@ export const CodeBlock = memo(
               <div className="i-ph:clipboard-text-duotone"></div>
             </button>
           )}
+          <button
+            className="flex items-center bg-accent-500 p-[6px] justify-center rounded-md transition-theme"
+            title="Ask Bolt about this code"
+            onClick={() => {
+              const askFn = (window as any).__BOLT_ASK_SNIPPET__;
+              if (typeof askFn === 'function') {
+                askFn(code, language);
+              }
+            }}
+          >
+            <div className="i-ph:chat-circle-duotone"></div>
+          </button>
         </div>
         <div dangerouslySetInnerHTML={{ __html: html ?? '' }}></div>
       </div>


### PR DESCRIPTION
## Summary
- enable sending selected code snippets to Bolt
- hook new window global in ChatBox
- show "Ask Bolt" button on code blocks
- adjust code block styles for multiple buttons

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @blitz/eslint-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6842359ff8588323852303225cf153f5

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add the "Ask Bolt" feature to code blocks in the chat, enabling users to inquire about code functionality directly.

### Why are these changes being made?

This feature enhances the user experience by allowing users to interactively query the purpose of code snippets directly from the chat interface, providing immediate insights into the code's functionality. The approach leverages the introduction of a new function, `__BOLT_ASK_SNIPPET__`, which simplifies initiating these queries and ensures integration within the existing chat pipeline.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->