### PR TITLE
Add project templates docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ project, please check the [project management guide](./PROJECT.md) to get starte
 - **Guided Setup Wizard** for Supabase and Firebase connections
 - **Import Figma designs** to generate starter UI code.
  - **Mobile starter templates** for React Native and Expo with [QR-code previews](docs/docs/mobile-preview.md) via Expo Go.
+- **Project templates** to kickstart your app with examples like a Blog, SaaS dashboard, or Ecommerce site. ([learn more](docs/docs/project-templates.md))
 
 ## Setup
 

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -137,4 +137,28 @@ export const STARTER_TEMPLATES: Template[] = [
     tags: ['angular', 'typescript', 'frontend', 'spa'],
     icon: 'i-bolt:angular',
   },
+  {
+    name: 'Blog',
+    label: 'Blog Template',
+    description: 'Basic blog starter to quickly publish articles',
+    githubRepo: 'xKevIsDev/bolt-blog-template',
+    tags: ['blog', 'content'],
+    icon: 'i-bolt:stars',
+  },
+  {
+    name: 'SaaS Dashboard',
+    label: 'SaaS Dashboard',
+    description: 'Starter dashboard layout for SaaS products',
+    githubRepo: 'xKevIsDev/bolt-saas-template',
+    tags: ['saas', 'dashboard'],
+    icon: 'i-bolt:stars',
+  },
+  {
+    name: 'Ecommerce',
+    label: 'Ecommerce Site',
+    description: 'Template for setting up an online store',
+    githubRepo: 'xKevIsDev/bolt-ecommerce-template',
+    tags: ['ecommerce', 'shop'],
+    icon: 'i-bolt:stars',
+  },
 ];

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -44,6 +44,7 @@ Also [this pinned post in our community](https://thinktank.ottomator.ai/t/videos
 - **One-click deployment** to **Netlify**, **Vercel**, or **Cloudflare Pages**.
 - **Import Figma designs** to bootstrap your UI code.
  - **Mobile starter templates** for React Native and Expo with [QR-code preview using Expo Go](mobile-preview.md).
+- **Project templates** to kickstart your app with examples like a Blog, SaaS dashboard, or Ecommerce site. ([learn more](project-templates.md))
 
 ---
 

--- a/docs/docs/project-templates.md
+++ b/docs/docs/project-templates.md
@@ -1,0 +1,9 @@
+# Project Templates
+
+bolt.diy lets you jumpstart new projects by cloning predefined templates. From the homepage choose **Start with template** and pick a starting point such as:
+
+- **Blog**
+- **SaaS dashboard**
+- **Ecommerce site**
+
+Once selected, bolt.diy imports the template files so you can immediately begin customizing and building your application.


### PR DESCRIPTION
## Summary
- document project templates on the homepage
- mention project templates in README
- add doc page describing templates
- add sample Blog, SaaS dashboard and Ecommerce templates

## Testing
- `pnpm lint` *(fails: Cannot find package '@blitz/eslint-plugin')*
- `pnpm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423e28fc6c8323a977d4983426d3c3

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add documentation and definitions for new project templates, including templates for a Blog, SaaS Dashboard, and Ecommerce site.

### Why are these changes being made?

These changes introduce predefined project templates to streamline the initial setup process for common application types, providing users with a quick start by importing relevant template files. This approach improves development efficiency and helps users get started faster with examples tailored to popular project types.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->