### PR TITLE
Add GitHub repo clone button

### DIFF
--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -16,7 +16,6 @@ import * as Tooltip from '@radix-ui/react-tooltip';
 import styles from './BaseChat.module.scss';
 import { ImportButtons } from '~/components/chat/chatExportAndImport/ImportButtons';
 import { ExamplePrompts } from '~/components/chat/ExamplePrompts';
-import GitCloneButton from './GitCloneButton';
 import type { ProviderInfo } from '~/types/model';
 import StarterTemplates from './StarterTemplates';
 import type { ActionAlert, SupabaseAlert, DeployAlert } from '~/types/actions';
@@ -489,7 +488,6 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
               {!chatStarted && (
                 <div className="flex justify-center gap-2">
                   {ImportButtons(importChat)}
-                  <GitCloneButton importChat={importChat} />
                 </div>
               )}
               <div className="flex flex-col gap-5">

--- a/app/components/chat/chatExportAndImport/ImportButtons.tsx
+++ b/app/components/chat/chatExportAndImport/ImportButtons.tsx
@@ -1,6 +1,7 @@
 import type { Message } from 'ai';
 import { toast } from 'react-toastify';
 import { ImportFolderButton } from '~/components/chat/ImportFolderButton';
+import GitCloneButton from '../GitCloneButton';
 import { Button } from '~/components/ui/Button';
 import { classNames } from '~/utils/classNames';
 
@@ -87,6 +88,17 @@ export function ImportButtons(importChat: ((description: string, messages: Messa
               'border border-[rgba(0,0,0,0.08)] dark:border-[rgba(255,255,255,0.08)]',
               'h-10 px-4 py-2 min-w-[120px] justify-center',
               'transition-all duration-200 ease-in-out rounded-lg',
+            )}
+          />
+          <GitCloneButton
+            importChat={importChat}
+            className={classNames(
+              'gap-2 bg-bolt-elements-background-depth-1',
+              'text-bolt-elements-textPrimary',
+              'hover:bg-bolt-elements-background-depth-2',
+              'border border-bolt-elements-borderColor',
+              'h-10 px-4 py-2 min-w-[120px] justify-center',
+              'transition-all duration-200 ease-in-out',
             )}
           />
         </div>


### PR DESCRIPTION
## Summary
- let users clone GitHub repos via the Import dialog
- remove the old standalone clone button

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684241c92080832380e4969135034f37

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add a GitHub repo clone button to the `ImportButtons` component for enhanced chat import functionality, and remove it from `BaseChat`.

### Why are these changes being made?
This change consolidates all import-related buttons within the `ImportButtons` component for improved component organization and user interaction. By repositioning the `GitCloneButton`, the structure becomes more intuitive and maintainable, ensuring that all import functionalities are accessible in one streamlined interface.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->