### PR TITLE
Improve diff generation

### DIFF
--- a/app/utils/diff.ts
+++ b/app/utils/diff.ts
@@ -35,13 +35,8 @@ export function computeFileModifications(files: FileMap, modifiedFiles: Map<stri
 
     hasModifiedFiles = true;
 
-    if (unifiedDiff.length > file.content.length) {
-      // if there are lots of changes we simply grab the current file content since it's smaller than the diff
-      modifications[filePath] = { type: 'file', content: file.content };
-    } else {
-      // otherwise we use the diff since it's smaller
-      modifications[filePath] = { type: 'diff', content: unifiedDiff };
-    }
+    // always send a diff so that only the changed lines are rewritten
+    modifications[filePath] = { type: 'diff', content: unifiedDiff };
   }
 
   if (!hasModifiedFiles) {
@@ -59,7 +54,8 @@ export function computeFileModifications(files: FileMap, modifiedFiles: Map<stri
  * @see https://www.gnu.org/software/diffutils/manual/html_node/Unified-Format.html
  */
 export function diffFiles(fileName: string, oldFileContent: string, newFileContent: string) {
-  let unifiedDiff = createTwoFilesPatch(fileName, fileName, oldFileContent, newFileContent);
+  // use 0 lines of context to keep the diff as small as possible
+  let unifiedDiff = createTwoFilesPatch(fileName, fileName, oldFileContent, newFileContent, '', '', { context: 0 });
 
   const patchHeaderEnd = `--- ${fileName}\n+++ ${fileName}\n`;
   const headerEndIndex = unifiedDiff.indexOf(patchHeaderEnd);


### PR DESCRIPTION
## Summary
- always send diff content even when large
- reduce diff context size to keep patches small

## Testing
- `pnpm test`
- `pnpm lint` *(fails: prettier issues)*

------
https://chatgpt.com/codex/tasks/task_e_684246942f888323be8da3ac984ded3c

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Simplify the diff generation logic by always sending the unified diff with 0 lines of context, ensuring only changes are captured.

### Why are these changes being made?

The previous implementation conditionally sent either the entire file content or a diff based on size, which could result in unnecessary data transfer when the whole content was smaller. By always providing the diff with minimal context (0 lines), data efficiency is improved, reducing the overall payload size and more appropriately reflecting only the changes. This change should streamline the modification handling and enhance performance in diff-related operations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->