### PR TITLE
Add docs readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,31 @@
+# Documentation Overview
+
+This directory contains the sources used to generate the **bolt.diy** documentation site.
+It uses [MkDocs](https://www.mkdocs.org/) with the Material theme to build a static site from the files in [`docs/docs`](docs/docs).
+The build configuration lives in [`mkdocs.yml`](mkdocs.yml).
+
+## Building or Serving the Docs
+
+1. Install the documentation dependencies using [Poetry](https://python-poetry.org/):
+
+   ```bash
+   cd docs
+   poetry install
+   ```
+
+2. To preview the documentation locally, run:
+
+   ```bash
+   poetry run mkdocs serve -f mkdocs.yml
+   ```
+
+   This starts a local server and watches for changes.
+
+3. To generate the static site, run:
+
+   ```bash
+   poetry run mkdocs build -f mkdocs.yml
+   ```
+
+   The site will be output to the directory specified by `site_dir` in `mkdocs.yml` (currently `../site`).
+


### PR DESCRIPTION
## Summary
- explain the purpose of the docs folder
- show how to serve or build the docs with mkdocs and docs/mkdocs.yml

## Testing
- `pnpm lint` *(fails: Cannot find module `@blitz/eslint-plugin`)*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68424b014b248323b2d22e4eeac41830

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a README to the `docs` directory providing an overview of the documentation build process and instructions on how to build or serve the documentation locally.

### Why are these changes being made?

To offer clear guidance to contributors on how to work with the documentation by using MkDocs with the Material theme. This ensures anyone can easily build or preview the documentation, facilitating collaboration and consistency in document maintenance.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->