### PR TITLE
Implement feature flag handling

### DIFF
--- a/app/lib/api/features.ts
+++ b/app/lib/api/features.ts
@@ -1,35 +1,76 @@
 export interface Feature {
+  /**
+   * Unique identifier for the feature.
+   */
   id: string;
+  /**
+   * Short title of the feature to display in the UI.
+   */
   name: string;
+  /**
+   * Description of what the feature does.
+   */
   description: string;
+  /**
+   * Whether the user has already viewed/acknowledged this feature.
+   */
   viewed: boolean;
+  /**
+   * ISO date string for when the feature was released.
+   */
   releaseDate: string;
 }
 
+const VIEWED_FEATURES_KEY = 'bolt_viewed_features';
+
+// Import client-side localStorage helpers
+import { getLocalStorage, setLocalStorage } from '~/lib/persistence';
+
+interface FeatureFromFile {
+  id: string;
+  name: string;
+  description: string;
+  releaseDate: string;
+}
+
+/**
+ * Fetch the list of available features from the bundled features.json file
+ * and mark each one as viewed or not based on localStorage state.
+ */
 export const getFeatureFlags = async (): Promise<Feature[]> => {
-  /*
-   * TODO: Implement actual feature flags logic
-   * This is a mock implementation
-   */
-  return [
-    {
-      id: 'feature-1',
-      name: 'Dark Mode',
-      description: 'Enable dark mode for better night viewing',
-      viewed: true,
-      releaseDate: '2024-03-15',
-    },
-    {
-      id: 'feature-2',
-      name: 'Tab Management',
-      description: 'Customize your tab layout',
-      viewed: false,
-      releaseDate: '2024-03-20',
-    },
-  ];
+  try {
+    const response = await fetch('/features.json', { cache: 'no-cache' });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch features.json: ${response.status}`);
+    }
+
+    const data = (await response.json()) as FeatureFromFile[];
+    const viewedIds: string[] = getLocalStorage(VIEWED_FEATURES_KEY) || [];
+
+    return data.map((feature) => ({
+      ...feature,
+      viewed: viewedIds.includes(feature.id),
+    }));
+  } catch (error) {
+    console.error('Error loading feature flags:', error);
+    return [];
+  }
 };
 
+/**
+ * Persist that a feature has been viewed by the user.
+ * The viewed state is stored locally in the browser via localStorage.
+ */
 export const markFeatureViewed = async (featureId: string): Promise<void> => {
-  /* TODO: Implement actual feature viewed logic */
-  console.log(`Marking feature ${featureId} as viewed`);
+  try {
+    const viewedIds: string[] = getLocalStorage(VIEWED_FEATURES_KEY) || [];
+
+    if (!viewedIds.includes(featureId)) {
+      viewedIds.push(featureId);
+      setLocalStorage(VIEWED_FEATURES_KEY, viewedIds);
+    }
+  } catch (error) {
+    console.error(`Failed to mark feature ${featureId} as viewed:`, error);
+  }
 };

--- a/public/features.json
+++ b/public/features.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "lock-files",
+    "name": "File Locking",
+    "description": "Protect important files from accidental changes by locking them",
+    "releaseDate": "2024-05-01"
+  },
+  {
+    "id": "code-search",
+    "name": "Code Search",
+    "description": "Quickly search your project files using the new search bar",
+    "releaseDate": "2024-05-15"
+  },
+  {
+    "id": "vercel-deploy",
+    "name": "Vercel Deploy",
+    "description": "Deploy your project to Vercel directly from the interface",
+    "releaseDate": "2024-05-22"
+  }
+]


### PR DESCRIPTION
## Summary
- implement feature flag retrieval and persistence
- add sample `public/features.json` file

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68424b0252148323b84182bf698cb249

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement feature flag handling by introducing the `getFeatureFlags` and `markFeatureViewed` functions, which fetch and manage feature flag states using `localStorage`, and add a new `features.json` file to list available features.

### Why are these changes being made?

These changes address the need for dynamic feature flag management by replacing the mock implementation with functionality that fetches feature data from a JSON file and tracks user interactions persistently at the client level. This approach enhances user experience by allowing tailored feature visibility and adoption.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->