### PR TITLE
Parameterize action stream sample delay

### DIFF
--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -17,6 +17,7 @@ import { extractRelativePath } from '~/utils/diff';
 import { description } from '~/lib/persistence';
 import Cookies from 'js-cookie';
 import { createSampler } from '~/utils/sampler';
+import { ACTION_STREAM_SAMPLE_INTERVAL } from '~/utils/constants';
 import type { ActionAlert, DeployAlert, SupabaseAlert } from '~/types/actions';
 
 const { saveAs } = fileSaver;
@@ -604,9 +605,12 @@ export class WorkbenchStore {
     }
   }
 
-  actionStreamSampler = createSampler(async (data: ActionCallbackData, isStreaming: boolean = false) => {
-    return await this._runAction(data, isStreaming);
-  }, 100); // TODO: remove this magic number to have it configurable
+  actionStreamSampler = createSampler(
+    async (data: ActionCallbackData, isStreaming: boolean = false) => {
+      return await this._runAction(data, isStreaming);
+    },
+    ACTION_STREAM_SAMPLE_INTERVAL,
+  );
 
   #getArtifact(id: string) {
     const artifacts = this.artifacts.get();

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -8,6 +8,8 @@ export const MODEL_REGEX = /^\[Model: (.*?)\]\n\n/;
 export const PROVIDER_REGEX = /\[Provider: (.*?)\]\n\n/;
 export const DEFAULT_MODEL = 'claude-3-5-sonnet-latest';
 export const PROMPT_COOKIE_KEY = 'cachedPrompt';
+// Interval used by actionStreamSampler in ms
+export const ACTION_STREAM_SAMPLE_INTERVAL = 100;
 
 const llmManager = LLMManager.getInstance(import.meta.env);
 


### PR DESCRIPTION
## Summary
- add `ACTION_STREAM_SAMPLE_INTERVAL` constant
- use the new constant in `actionStreamSampler`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find ESLint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68424b046e9083238a613690e2b27346