### PR TITLE
Fix update-imports script newline

### DIFF
--- a/scripts/update-imports.sh
+++ b/scripts/update-imports.sh
@@ -4,4 +4,4 @@
 find app -type f -name "*.ts" -o -name "*.tsx" | xargs sed -i '' 's|~/components/settings/settings.types|~/components/@settings/core/types|g'
 
 # Update imports for specific components
-find app -type f -name "*.ts" -o -name "*.tsx" | xargs sed -i '' 's|~/components/settings/|~/components/@settings/tabs/|g' 
+find app -type f -name "*.ts" -o -name "*.tsx" | xargs sed -i '' 's|~/components/settings/|~/components/@settings/tabs/|g'


### PR DESCRIPTION
## Summary
- cleanup scripts/update-imports.sh

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68424e3634d883239115b8dddaca0288


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
