### PR TITLE
Update tsconfig exclude and fix tab labels

### DIFF
--- a/app/components/@settings/core/types.ts
+++ b/app/components/@settings/core/types.ts
@@ -79,6 +79,7 @@ export const TAB_LABELS: Record<TabType, string> = {
   connection: 'Connections',
   debug: 'Debug',
   'event-logs': 'Event Logs',
+  notes: 'Notes',
   update: 'Updates',
   'task-manager': 'Task Manager',
   'tab-management': 'Tab Management',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,5 +35,9 @@
     "**/.server/**/*.tsx",
     "**/.client/**/*.ts",
     "**/.client/**/*.tsx"
+  ],
+  "exclude": [
+    "mobile",
+    "examples"
   ]
 }


### PR DESCRIPTION
## Summary
- prevent TypeScript from checking `mobile` and `examples` folders
- fix missing tab label for `notes`

## Testing
- `pnpm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68424ec41c8483238916c0910ccdf585


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
