### PR TITLE
Fix guard in NotesTab handleAdd and lint repo

### DIFF
--- a/app/components/@settings/tabs/notes/NotesTab.tsx
+++ b/app/components/@settings/tabs/notes/NotesTab.tsx
@@ -10,7 +10,11 @@ export default function NotesTab() {
 
   const handleAdd = () => {
     const text = noteText.trim();
-    if (!text) return;
+
+    if (!text) {
+      return;
+    }
+
     addNote(text);
     setNoteText('');
   };
@@ -27,7 +31,7 @@ export default function NotesTab() {
             'border border-bolt-elements-borderColor',
             'text-bolt-elements-textPrimary',
             'focus:outline-none focus:ring-2 focus:ring-purple-500/30',
-            'min-h-[80px] resize-vertical'
+            'min-h-[80px] resize-vertical',
           )}
           placeholder="Add a note for the AI"
         />
@@ -37,25 +41,14 @@ export default function NotesTab() {
       </div>
       <div className="space-y-2">
         {notes.map((n) => (
-          <div
-            key={n.id}
-            className="flex items-start gap-2 p-2 rounded-lg bg-bolt-elements-background-depth-2"
-          >
-            <div className="flex-1 whitespace-pre-wrap text-sm text-bolt-elements-textPrimary">
-              {n.text}
-            </div>
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={() => removeNote(n.id)}
-            >
+          <div key={n.id} className="flex items-start gap-2 p-2 rounded-lg bg-bolt-elements-background-depth-2">
+            <div className="flex-1 whitespace-pre-wrap text-sm text-bolt-elements-textPrimary">{n.text}</div>
+            <Button size="sm" variant="ghost" onClick={() => removeNote(n.id)}>
               <div className="i-ph:trash w-4 h-4" />
             </Button>
           </div>
         ))}
-        {notes.length === 0 && (
-          <p className="text-sm text-bolt-elements-textSecondary">No notes added.</p>
-        )}
+        {notes.length === 0 && <p className="text-sm text-bolt-elements-textSecondary">No notes added.</p>}
       </div>
     </div>
   );

--- a/app/components/chat/BaseChat.tsx
+++ b/app/components/chat/BaseChat.tsx
@@ -485,11 +485,7 @@ export const BaseChat = React.forwardRef<HTMLDivElement, BaseChatProps>(
               </div>
             </StickToBottom>
             <div className="flex flex-col justify-center">
-              {!chatStarted && (
-                <div className="flex justify-center gap-2">
-                  {ImportButtons(importChat)}
-                </div>
-              )}
+              {!chatStarted && <div className="flex justify-center gap-2">{ImportButtons(importChat)}</div>}
               <div className="flex flex-col gap-5">
                 {!chatStarted &&
                   ExamplePrompts((event, messageInput) => {

--- a/app/components/chat/CodeBlock.tsx
+++ b/app/components/chat/CodeBlock.tsx
@@ -82,6 +82,7 @@ export const CodeBlock = memo(
             title="Ask Bolt about this code"
             onClick={() => {
               const askFn = (window as any).__BOLT_ASK_SNIPPET__;
+
               if (typeof askFn === 'function') {
                 askFn(code, language);
               }

--- a/app/components/chat/chatExportAndImport/ImportButtons.tsx
+++ b/app/components/chat/chatExportAndImport/ImportButtons.tsx
@@ -1,7 +1,7 @@
 import type { Message } from 'ai';
 import { toast } from 'react-toastify';
 import { ImportFolderButton } from '~/components/chat/ImportFolderButton';
-import GitCloneButton from '../GitCloneButton';
+import GitCloneButton from '~/components/chat/GitCloneButton';
 import { Button } from '~/components/ui/Button';
 import { classNames } from '~/utils/classNames';
 

--- a/app/components/setup/SetupWizard.tsx
+++ b/app/components/setup/SetupWizard.tsx
@@ -47,10 +47,22 @@ export function SetupWizard() {
               <div className="space-y-4">
                 <DialogTitle>Select a Provider</DialogTitle>
                 <div className="flex gap-2">
-                  <DialogButton type="primary" onClick={() => { setProvider('supabase'); setStep(2); }}>
+                  <DialogButton
+                    type="primary"
+                    onClick={() => {
+                      setProvider('supabase');
+                      setStep(2);
+                    }}
+                  >
                     Supabase
                   </DialogButton>
-                  <DialogButton type="primary" onClick={() => { setProvider('firebase'); setStep(2); }}>
+                  <DialogButton
+                    type="primary"
+                    onClick={() => {
+                      setProvider('firebase');
+                      setStep(2);
+                    }}
+                  >
                     Firebase
                   </DialogButton>
                 </div>
@@ -85,7 +97,9 @@ export function SetupWizard() {
                 )}
                 {supabaseConn.credentials && (
                   <div className="space-y-2 text-xs bg-bolt-elements-background-depth-3 p-3 rounded">
-                    <div>Add these to your <code>.env.local</code>:</div>
+                    <div>
+                      Add these to your <code>.env.local</code>:
+                    </div>
                     <pre>{`VITE_SUPABASE_URL=${supabaseConn.credentials.supabaseUrl}\nVITE_SUPABASE_ANON_KEY=${supabaseConn.credentials.anonKey}`}</pre>
                     <div className="mt-2">Sample code:</div>
                     <pre>{`import { createClient } from '@supabase/supabase-js';\n\nexport const supabase = createClient(import.meta.env.VITE_SUPABASE_URL!, import.meta.env.VITE_SUPABASE_ANON_KEY!);`}</pre>
@@ -111,12 +125,16 @@ export function SetupWizard() {
                   value={firebase.projectId}
                   onChange={(e) => updateFirebaseConfig({ projectId: e.currentTarget.value })}
                 />
-                <DialogButton type="primary" onClick={handleFirebaseSave}>Save</DialogButton>
+                <DialogButton type="primary" onClick={handleFirebaseSave}>
+                  Save
+                </DialogButton>
               </div>
             )}
             {provider === 'firebase' && step === 3 && (
               <div className="space-y-2 text-xs bg-bolt-elements-background-depth-3 p-3 rounded">
-                <div>Add these to your <code>.env.local</code>:</div>
+                <div>
+                  Add these to your <code>.env.local</code>:
+                </div>
                 <pre>{`VITE_FIREBASE_API_KEY=${firebase.apiKey}\nVITE_FIREBASE_AUTH_DOMAIN=${firebase.authDomain}\nVITE_FIREBASE_PROJECT_ID=${firebase.projectId}`}</pre>
                 <div className="mt-2">Sample code:</div>
                 <pre>{`import { initializeApp } from 'firebase/app';\nimport { getAuth } from 'firebase/auth';\nimport { getFirestore } from 'firebase/firestore';\n\nconst firebaseConfig = {\n  apiKey: import.meta.env.VITE_FIREBASE_API_KEY!,\n  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN!,\n  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID!,\n};\n\nconst app = initializeApp(firebaseConfig);\nexport const auth = getAuth(app);\nexport const db = getFirestore(app);`}</pre>

--- a/app/lib/api/features.ts
+++ b/app/lib/api/features.ts
@@ -3,18 +3,22 @@ export interface Feature {
    * Unique identifier for the feature.
    */
   id: string;
+
   /**
    * Short title of the feature to display in the UI.
    */
   name: string;
+
   /**
    * Description of what the feature does.
    */
   description: string;
+
   /**
    * Whether the user has already viewed/acknowledged this feature.
    */
   viewed: boolean;
+
   /**
    * ISO date string for when the feature was released.
    */

--- a/app/lib/common/prompt-library.ts
+++ b/app/lib/common/prompt-library.ts
@@ -31,24 +31,12 @@ export class PromptLibrary {
     default: {
       label: 'Default Prompt',
       description: 'This is the battle tested default system Prompt',
-      get: (options) =>
-        getSystemPrompt(
-          options.cwd,
-          options.supabase,
-          options.designScheme,
-          options.userNotes,
-        ),
+      get: (options) => getSystemPrompt(options.cwd, options.supabase, options.designScheme, options.userNotes),
     },
     enhanced: {
       label: 'Fine Tuned Prompt',
       description: 'An fine tuned prompt for better results',
-      get: (options) =>
-        getFineTunedPrompt(
-          options.cwd,
-          options.supabase,
-          options.designScheme,
-          options.userNotes,
-        ),
+      get: (options) => getFineTunedPrompt(options.cwd, options.supabase, options.designScheme, options.userNotes),
     },
     optimized: {
       label: 'Optimized Prompt (experimental)',

--- a/app/lib/stores/notes.ts
+++ b/app/lib/stores/notes.ts
@@ -12,6 +12,7 @@ function loadNotes(): Note[] {
   if (typeof localStorage === 'undefined') {
     return [];
   }
+
   try {
     const json = localStorage.getItem(NOTES_KEY);
     return json ? JSON.parse(json) : [];
@@ -21,7 +22,10 @@ function loadNotes(): Note[] {
 }
 
 function saveNotes(notes: Note[]) {
-  if (typeof localStorage === 'undefined') return;
+  if (typeof localStorage === 'undefined') {
+    return;
+  }
+
   try {
     localStorage.setItem(NOTES_KEY, JSON.stringify(notes));
   } catch {}

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -629,12 +629,9 @@ export class WorkbenchStore {
     }
   }
 
-  actionStreamSampler = createSampler(
-    async (data: ActionCallbackData, isStreaming: boolean = false) => {
-      return await this._runAction(data, isStreaming);
-    },
-    ACTION_STREAM_SAMPLE_INTERVAL,
-  );
+  actionStreamSampler = createSampler(async (data: ActionCallbackData, isStreaming: boolean = false) => {
+    return await this._runAction(data, isStreaming);
+  }, ACTION_STREAM_SAMPLE_INTERVAL);
 
   #getArtifact(id: string) {
     const artifacts = this.artifacts.get();

--- a/app/routes/api.chat.ts
+++ b/app/routes/api.chat.ts
@@ -38,23 +38,24 @@ function parseCookies(cookieHeader: string): Record<string, string> {
 }
 
 async function chatAction({ context, request }: ActionFunctionArgs) {
-  const { messages, files, promptId, contextOptimization, supabase, chatMode, designScheme, userNotes } = await request.json<{
-    messages: Messages;
-    files: any;
-    promptId?: string;
-    contextOptimization: boolean;
-    chatMode: 'discuss' | 'build';
-    designScheme?: DesignScheme;
-    userNotes?: string;
-    supabase?: {
-      isConnected: boolean;
-      hasSelectedProject: boolean;
-      credentials?: {
-        anonKey?: string;
-        supabaseUrl?: string;
+  const { messages, files, promptId, contextOptimization, supabase, chatMode, designScheme, userNotes } =
+    await request.json<{
+      messages: Messages;
+      files: any;
+      promptId?: string;
+      contextOptimization: boolean;
+      chatMode: 'discuss' | 'build';
+      designScheme?: DesignScheme;
+      userNotes?: string;
+      supabase?: {
+        isConnected: boolean;
+        hasSelectedProject: boolean;
+        credentials?: {
+          anonKey?: string;
+          supabaseUrl?: string;
+        };
       };
-    };
-  }>();
+    }>();
 
   const cookieHeader = request.headers.get('Cookie');
   const apiKeys = JSON.parse(parseCookies(cookieHeader || '').apiKeys || '{}');

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -8,6 +8,7 @@ export const MODEL_REGEX = /^\[Model: (.*?)\]\n\n/;
 export const PROVIDER_REGEX = /\[Provider: (.*?)\]\n\n/;
 export const DEFAULT_MODEL = 'claude-3-5-sonnet-latest';
 export const PROMPT_COOKIE_KEY = 'cachedPrompt';
+
 // Interval used by actionStreamSampler in ms
 export const ACTION_STREAM_SAMPLE_INTERVAL = 100;
 


### PR DESCRIPTION
## Summary
- adjust add-note guard in NotesTab
- update ImportButtons import path
- format repo with `pnpm run lint:fix`

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68424ec6439c83239fa9871a9e0e4fd3

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the guard clause within the `handleAdd` function in `NotesTab`, and apply consistent formatting throughout the codebase using a linter.

### Why are these changes being made?

The improper guard clause in `handleAdd` could potentially lead to logical errors if `text` is empty, and improving code formatting with a linter enhances readability and maintainability, aligning with coding standards.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->