### PR TITLE
Fix unist type import

### DIFF
--- a/app/utils/markdown.ts
+++ b/app/utils/markdown.ts
@@ -3,7 +3,7 @@ import remarkGfm from 'remark-gfm';
 import type { PluggableList, Plugin } from 'unified';
 import rehypeSanitize, { defaultSchema, type Options as RehypeSanitizeOptions } from 'rehype-sanitize';
 import { SKIP, visit } from 'unist-util-visit';
-import type { UnistNode, UnistParent } from 'node_modules/unist-util-visit/lib';
+import type { Node as UnistNode, Parent as UnistParent } from 'unist';
 
 export const allowedHTMLElements = [
   'a',


### PR DESCRIPTION
## Summary
- switch Markdown utils to use `Node`/`Parent` from stable `unist`

## Testing
- `pnpm run typecheck` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6842515be4108323a08e516d31b2c090

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the import statement for Unist types by updating the source to 'unist'.

### Why are these changes being made?

The previous import path for `UnistNode` and `UnistParent` was incorrect, leading to potential build or runtime errors. Changing the import path to 'unist' ensures compatibility with the correct library and avoids these issues.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->