### PR TITLE
Fix SSR compatibility in useViewport

### DIFF
--- a/app/lib/hooks/useViewport.ts
+++ b/app/lib/hooks/useViewport.ts
@@ -1,10 +1,28 @@
 import { useState, useEffect } from 'react';
 
-const useViewport = (threshold = 1024) => {
-  const [isSmallViewport, setIsSmallViewport] = useState(window.innerWidth < threshold);
+/**
+ * Determine the current viewport width in both browser and server contexts.
+ * When `window` is not available (e.g. during SSR), a fallback width is used.
+ */
+const getWidth = (fallback: number): number =>
+  typeof window !== 'undefined' ? window.innerWidth : fallback;
+
+/**
+ * Returns `true` if the viewport width is less than the provided threshold.
+ * A `fallbackWidth` can be supplied for server environments where `window`
+ * is undefined.
+ */
+const useViewport = (threshold = 1024, fallbackWidth = 1024) => {
+  const [isSmallViewport, setIsSmallViewport] = useState(
+    getWidth(fallbackWidth) < threshold,
+  );
 
   useEffect(() => {
-    const handleResize = () => setIsSmallViewport(window.innerWidth < threshold);
+    if (typeof window === 'undefined') return;
+
+    const handleResize = () =>
+      setIsSmallViewport(window.innerWidth < threshold);
+
     window.addEventListener('resize', handleResize);
 
     return () => {


### PR DESCRIPTION
## Summary
- update `useViewport` to guard against `window` usage during SSR
- support a configurable fallback width for server environments

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425159b9f883238d48be529d2f7a86

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Improve Server-Side Rendering (SSR) compatibility in the `useViewport` hook by adding a `getWidth` function to handle viewport width determination in server environments and expanding existing logic to accommodate server contexts.

### Why are these changes being made?

These changes address issues where `window` is undefined in server environments, notably during SSR, by introducing a fallback width mechanism, ensuring the `useViewport` hook functions correctly when executed in both server and browser contexts. This approach avoids errors and ensures consistent behavior across different environments.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->