### PR TITLE
Fix cleanup script removal process

### DIFF
--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -1,4 +1,4 @@
-import { rm, existsSync } from 'fs';
+import { promises as fs, existsSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
@@ -11,23 +11,23 @@ const dirsToRemove = ['node_modules/.vite', 'node_modules/.cache', '.cache', 'di
 
 console.log('🧹 Cleaning project...');
 
-// Remove directories
-for (const dir of dirsToRemove) {
-  const fullPath = join(__dirname, '..', dir);
+// Remove directories sequentially
+async function removeDirectories() {
+  for (const dir of dirsToRemove) {
+    const fullPath = join(__dirname, '..', dir);
 
-  try {
-    if (existsSync(fullPath)) {
-      console.log(`Removing ${dir}...`);
-      rm(fullPath, { recursive: true, force: true }, (err) => {
-        if (err) {
-          console.error(`Error removing ${dir}:`, err.message);
-        }
-      });
+    try {
+      if (existsSync(fullPath)) {
+        console.log(`Removing ${dir}...`);
+        await fs.rm(fullPath, { recursive: true, force: true });
+      }
+    } catch (err) {
+      console.error(`Error removing ${dir}:`, err.message);
     }
-  } catch (err) {
-    console.error(`Error removing ${dir}:`, err.message);
   }
 }
+
+await removeDirectories();
 
 // Run pnpm commands
 console.log('\n📦 Reinstalling dependencies...');


### PR DESCRIPTION
## Summary
- ensure directories are removed sequentially before reinstalling packages
- use `fs.promises.rm` with `await` for reliable cleanup

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684251607d588323b8aa8bb4f95af584

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the cleanup script to use `fs.promises` for asynchronous directory removal in a sequential manner.

### Why are these changes being made?

The previous implementation used a callback-based approach that was less efficient and not sequential, potentially leading to race conditions when removing directories. This refactor ensures directories are removed singly and synchronously, leveraging async/await for improved reliability and clarity in error handling.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->