### PR TITLE
Fix dynamic import for system info

### DIFF
--- a/app/routes/api.system.disk-info.ts
+++ b/app/routes/api.system.disk-info.ts
@@ -8,8 +8,8 @@ try {
   // Check if we're in a Node.js environment
   if (typeof process !== 'undefined' && process.platform) {
     // Using dynamic import to avoid require()
-    const childProcess = { execSync: null };
-    execSync = childProcess.execSync;
+    const { execSync: importedExecSync } = await import('child_process');
+    execSync = importedExecSync;
   }
 } catch {
   // In Cloudflare environment, this will fail, which is expected

--- a/app/routes/api.system.memory-info.ts
+++ b/app/routes/api.system.memory-info.ts
@@ -8,8 +8,8 @@ try {
   // Check if we're in a Node.js environment
   if (typeof process !== 'undefined' && process.platform) {
     // Using dynamic import to avoid require()
-    const childProcess = { execSync: null };
-    execSync = childProcess.execSync;
+    const { execSync: importedExecSync } = await import('child_process');
+    execSync = importedExecSync;
   }
 } catch {
   // In Cloudflare environment, this will fail, which is expected

--- a/app/routes/api.system.process-info.ts
+++ b/app/routes/api.system.process-info.ts
@@ -8,8 +8,8 @@ try {
   // Check if we're in a Node.js environment
   if (typeof process !== 'undefined' && process.platform) {
     // Using dynamic import to avoid require()
-    const childProcess = { execSync: null };
-    execSync = childProcess.execSync;
+    const { execSync: importedExecSync } = await import('child_process');
+    execSync = importedExecSync;
   }
 } catch {
   // In Cloudflare environment, this will fail, which is expected


### PR DESCRIPTION
## Summary
- import `execSync` dynamically in api system info routes

## Testing
- `pnpm test`
- `pnpm run lint`
- `pnpm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68425760dc8c8323b5ba016dd7cc4493

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Replace `require()` with dynamic `import()` for `execSync` from `child_process` in various system info routes.

### Why are these changes being made?

These changes ensure compatibility with module-based environments by using ES module dynamic imports instead of CommonJS `require()`. This approach aligns with modern JavaScript standards and resolves issues related to asynchronous module loading, especially in environments like Node.js or serverless platforms where `require()` might not be suitable or may lead to execution errors.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->